### PR TITLE
fix: improve the stability and reliability of the tests

### DIFF
--- a/src/test/java/hotel/pages/ConfirmPage.java
+++ b/src/test/java/hotel/pages/ConfirmPage.java
@@ -18,6 +18,7 @@ public class ConfirmPage {
   public ConfirmPage(WebDriver driver) {
     this.driver = driver;
     this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("宿泊予約確認"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("宿泊予約確認")) {
       throw new IllegalStateException("現在のページが間違っています: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/IconPage.java
+++ b/src/test/java/hotel/pages/IconPage.java
@@ -1,17 +1,24 @@
 package hotel.pages;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.Color;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class IconPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public IconPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("アイコン設定"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("アイコン設定")) {
       throw new IllegalStateException("現在のページが間違っています: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/LoginPage.java
+++ b/src/test/java/hotel/pages/LoginPage.java
@@ -1,14 +1,21 @@
 package hotel.pages;
 
+import java.time.Duration;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class LoginPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public LoginPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("ログイン"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("ログイン")) {
       throw new IllegalStateException("現在のページが間違っています: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/MyPage.java
+++ b/src/test/java/hotel/pages/MyPage.java
@@ -1,15 +1,22 @@
 package hotel.pages;
 
+import java.time.Duration;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.Color;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class MyPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public MyPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("マイページ"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("マイページ")) {
       throw new IllegalStateException("現在のページが間違っています: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/PlansPage.java
+++ b/src/test/java/hotel/pages/PlansPage.java
@@ -18,6 +18,7 @@ public class PlansPage {
   public PlansPage(WebDriver driver) {
     this.driver = driver;
     this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("宿泊プラン一覧"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("宿泊プラン一覧")) {
       throw new IllegalStateException("現在のページが間違っています: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/ReservePage.java
+++ b/src/test/java/hotel/pages/ReservePage.java
@@ -31,6 +31,7 @@ public class ReservePage {
   public ReservePage(WebDriver driver) {
     this.driver = driver;
     this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("宿泊予約"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("宿泊予約")) {
       throw new IllegalStateException("現在のページが間違っています: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/SignupPage.java
+++ b/src/test/java/hotel/pages/SignupPage.java
@@ -1,10 +1,13 @@
 package hotel.pages;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class SignupPage {
 
@@ -26,8 +29,12 @@ public class SignupPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public SignupPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("会員登録"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("会員登録")) {
       throw new IllegalStateException("現在のページが間違っています: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/TopPage.java
+++ b/src/test/java/hotel/pages/TopPage.java
@@ -1,14 +1,21 @@
 package hotel.pages;
 
+import java.time.Duration;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class TopPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public TopPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("HOTEL PLANISPHERE - テスト自動化練習サイト"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().equals("HOTEL PLANISPHERE - テスト自動化練習サイト")) {
       throw new IllegalStateException("現在のページが間違っています: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/TopPage.java
+++ b/src/test/java/hotel/pages/TopPage.java
@@ -15,7 +15,7 @@ public class TopPage {
   public TopPage(WebDriver driver) {
     this.driver = driver;
     this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
-    this.wait.until(ExpectedConditions.titleContains("HOTEL PLANISPHERE - テスト自動化練習サイト"));
+    this.wait.until(ExpectedConditions.titleIs("HOTEL PLANISPHERE - テスト自動化練習サイト"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().equals("HOTEL PLANISPHERE - テスト自動化練習サイト")) {
       throw new IllegalStateException("現在のページが間違っています: " + this.driver.getTitle());
     }


### PR DESCRIPTION
This pull request includes several changes to the test pages in the `src/test/java/hotel/pages` directory. The primary focus is on improving page load verification by adding explicit waits for specific page titles. Here are the most important changes:

### Page Load Verification:

* [`src/test/java/hotel/pages/ConfirmPage.java`](diffhunk://#diff-bcb5a542ffa023cf311c634df08ff92ac22a15747c8f321a119d14ab9f02c4c3R21): Added a wait to ensure the title contains "宿泊予約確認" before proceeding.
* [`src/test/java/hotel/pages/IconPage.java`](diffhunk://#diff-0d85b8c8ad56d9e0ee84fb5a540a800e7da3fc28574ac643aee32983bbbc00baR4-R21): Introduced a wait to confirm the title contains "アイコン設定" before any further actions.
* [`src/test/java/hotel/pages/LoginPage.java`](diffhunk://#diff-e72d597a90cfda555d11e535016d2564d88e8ee4318c4f995cdaf60caa218086R3-R18): Added a wait to verify the title contains "ログイン" before continuing.
* [`src/test/java/hotel/pages/MyPage.java`](diffhunk://#diff-c39727cf68d2b8215ada765a76424ac6f024253f5ac6436baa8cc02571bd27d5R3-R19): Implemented a wait to check that the title contains "マイページ" before proceeding.
* [`src/test/java/hotel/pages/PlansPage.java`](diffhunk://#diff-8c5905455b3894318a579cafff054096b7f833922c01c4dadbe9df221d9df621R21): Added a wait to ensure the title contains "宿泊プラン一覧" before any further actions.
* [`src/test/java/hotel/pages/ReservePage.java`](diffhunk://#diff-3c2e2117e8aba6aec20476617e15bd0d697e7a6ad2a3f1c05b81268a594e35f6R34): Introduced a wait to confirm the title contains "宿泊予約" before continuing.
* [`src/test/java/hotel/pages/SignupPage.java`](diffhunk://#diff-a3235738734e2450b79f78441bfb10eac77392ae15b29c925cde90a5e6677612R32-R37): Added a wait to verify the title contains "会員登録" before proceeding.
* [`src/test/java/hotel/pages/TopPage.java`](diffhunk://#diff-e50f87e5f701cebe28ac7deea1695ff520f7137665bbc5d9e9725ab9cf31c0b0R3-R18): Implemented a wait to check that the title contains "HOTEL PLANISPHERE - テスト自動化練習サイト" before any further actions.

### Import Statements:

* [`src/test/java/hotel/pages/IconPage.java`](diffhunk://#diff-0d85b8c8ad56d9e0ee84fb5a540a800e7da3fc28574ac643aee32983bbbc00baR4-R21): Added imports for `Duration`, `ExpectedConditions`, and `WebDriverWait`.
* [`src/test/java/hotel/pages/LoginPage.java`](diffhunk://#diff-e72d597a90cfda555d11e535016d2564d88e8ee4318c4f995cdaf60caa218086R3-R18): Added imports for `Duration`, `ExpectedConditions`, and `WebDriverWait`.
* [`src/test/java/hotel/pages/MyPage.java`](diffhunk://#diff-c39727cf68d2b8215ada765a76424ac6f024253f5ac6436baa8cc02571bd27d5R3-R19): Added imports for `Duration`, `ExpectedConditions`, and `WebDriverWait`.
* [`src/test/java/hotel/pages/SignupPage.java`](diffhunk://#diff-a3235738734e2450b79f78441bfb10eac77392ae15b29c925cde90a5e6677612R3-R10): Added imports for `Duration`, `ExpectedConditions`, and `WebDriverWait`.
* [`src/test/java/hotel/pages/TopPage.java`](diffhunk://#diff-e50f87e5f701cebe28ac7deea1695ff520f7137665bbc5d9e9725ab9cf31c0b0R3-R18): Added imports for `Duration`, `ExpectedConditions`, and `WebDriverWait`.