### PR TITLE
feat: disable password window

### DIFF
--- a/src/test/java/hotel/Utils.java
+++ b/src/test/java/hotel/Utils.java
@@ -2,6 +2,8 @@ package hotel;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
@@ -10,7 +12,8 @@ import org.openqa.selenium.chrome.ChromeOptions;
 
 public class Utils {
 
-  public static final String BASE_URL = Objects.requireNonNullElse(System.getenv("BASE_URL"), "https://hotel-example-site.takeyaqa.dev/ja");
+  public static final String BASE_URL = Objects.requireNonNullElse(System.getenv("BASE_URL"),
+      "https://hotel-example-site.takeyaqa.dev/ja");
 
   private Utils() {
     throw new AssertionError();
@@ -20,7 +23,14 @@ public class Utils {
     var githubActions = Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"));
     var remoteContainers = Boolean.parseBoolean(System.getenv("REMOTE_CONTAINERS"));
     var codespaces = Boolean.parseBoolean(System.getenv("CODESPACES"));
+
+    Map<String, Object> chromePrefs = new HashMap<>();
+    chromePrefs.put("credentials_enable_service", false);
+    chromePrefs.put("profile.password_manager_enabled", false);
+    chromePrefs.put("profile.password_manager_leak_detection", false);
+
     var options = new ChromeOptions();
+    options.setExperimentalOption("prefs", chromePrefs);
     if (githubActions) {
       options.addArguments("--headless");
     } else if (remoteContainers || codespaces) {


### PR DESCRIPTION
This pull request makes improvements to the `Utils` class in the `src/test/java/hotel` package, focusing on better browser configuration and minor formatting adjustments. The most significant changes include adding Chrome preferences to disable password management features and introducing a new import for `HashMap` and `Map`.

### Enhancements to browser configuration:
* Added a `Map<String, Object>` named `chromePrefs` to configure Chrome preferences, disabling password management features (`credentials_enable_service`, `profile.password_manager_enabled`, and `profile.password_manager_leak_detection`). These preferences are applied using `options.setExperimentalOption("prefs", chromePrefs)` in the `createWebDriver` method.

### Codebase improvements:
* Added imports for `HashMap` and `Map` to support the new Chrome preferences.
* Reformatted the `BASE_URL` constant for better readability by splitting the default URL onto a new line.