### PR TITLE
chore: remove repository migration notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,6 @@
 
 [![selenium4-java-ja](https://github.com/takeyaqa/hotel-example-selenium4-java-ja/actions/workflows/test.yml/badge.svg)](https://github.com/takeyaqa/hotel-example-selenium4-java-ja/actions/workflows/test.yml)
 
----
-
-## リポジトリ移動のお知らせ
-
-> [!IMPORTANT]
-> このリポジトリは現在、個人所有に移行しました。以前は [Test Planisphere](https://github.com/testplanisphere) によって管理されていましたが、今後は [@takeyaqa](https://github.com/takeyaqa) によって管理されます。
->
-> リポジトリの新しいURLはこちらです：
-> 
-> [https://github.com/takeyaqa/hotel-example-selenium4-java-ja](https://github.com/takeyaqa/hotel-example-selenium4-java-ja)
-> 
-> この変更により、リポジトリの内容や目的に影響はありませんが、クローンしたりフォークしたプロジェクトのリモートURLを更新する必要がある場合があります。
-
----
-
 このプロジェクトはテスト自動化学習のためのサンプルコードです。
 
 ### テスト対象


### PR DESCRIPTION
This pull request removes outdated information about the repository's ownership transition from the `README.md` file. 

Ownership transition notice removal:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-L19): Deleted the section notifying users about the repository's ownership transition from `Test Planisphere` to `@takeyaqa`, including the new URL and instructions for updating remote URLs.