### PR TITLE
ci: remove matrix strategy and BASE_URL environment variable from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        base-url: ["https://hotel-example-site.takeyaqa.dev/ja", "https://hotel.testplanisphere.dev/ja"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -22,5 +19,3 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
     - name: Build with Gradle Wrapper
       run: ./gradlew test
-      env:
-        BASE_URL: ${{ matrix.base-url }}


### PR DESCRIPTION
This pull request simplifies the `.github/workflows/test.yml` file by removing the matrix strategy and associated environment variable setup. These changes streamline the workflow configuration for testing.

Workflow simplification:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L10-L12): Removed the `matrix` strategy under the `test` job, which previously defined multiple `base-url` values.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L25-L26): Eliminated the `BASE_URL` environment variable setup, which was tied to the removed `matrix.base-url`.